### PR TITLE
print debug to STDERR

### DIFF
--- a/maildir-to-ics
+++ b/maildir-to-ics
@@ -75,7 +75,7 @@ VEVENTS_TZIDS = {}
 def verbose_print(s, level=1):
     global VERBOSE
     if VERBOSE >= level:
-        print s
+        print >>sys.stderr, s
 
 
 class LineUnwrapper:


### PR DESCRIPTION
Debug should never be mixed with ics output.  Redirect it to STDERR so that

```
maildir-to-ics -v --maildir=$foo > foo.ics
```

will always generate valid ics files.
