### PR TITLE
drop unused lines variable

### DIFF
--- a/maildir-to-ics
+++ b/maildir-to-ics
@@ -188,7 +188,6 @@ def save_vevent(mail, vevent, uid,
 
         fb = open(path)
         content = LineUnwrapper(fb.read())
-        lines = fb.readlines()
         fb.close()
 
         for (real_lines, line) in content.each_line():


### PR DESCRIPTION
`readlines()` doesn't return anything here anyway, since the content was already read.