### PR TITLE
fix crash writing ics to file via STDOUT

### DIFF
--- a/maildir-to-ics
+++ b/maildir-to-ics
@@ -26,6 +26,7 @@
 #
 
 
+import codecs
 import errno
 import os
 import string
@@ -548,7 +549,7 @@ def write_ics_from_dir(vevents_directory, vtimezones_directory, dest, limit_past
     if dest is not None:
         fp = io.open(dest, 'w', newline='\r\n')
     else:
-        fp = sys.stdout
+        fp = codecs.getwriter('utf8')(sys.stdout)
 
     fp.write(u'BEGIN:VCALENDAR\n')
     fp.write(u'VERSION:2.0\n')


### PR DESCRIPTION
Fix a crash if the vevent contained non-ascii characters (e.g. in the `DESCRIPTION` field):

```
Traceback (most recent call last):
  File "/home/adam/bin/maildir-to-ics", line 898, in <module>
    ret = main(sys.argv)
  File "/home/adam/bin/maildir-to-ics", line 876, in main
    dest_ics, limit_past, limit_future)
  File "/home/adam/bin/maildir-to-ics", line 578, in write_ics_from_dir
    fp.write(buf)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 2912: ordinal not in range(128)
```

This happened because when redirecting `STDOUT` to a file, `sys.stdout.encoding` will be `None`.  Another way of fixing this is to set the `PYTHONIOENCODING` environment variable, but it's better to fix inside the program rather than requiring the user to do this.
